### PR TITLE
add HCL support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,4 +5,7 @@ Changelog
 Unreleased
 ==========
 
+- *[FEATURE]* Add support for the `HCL <https://github.com/hashicorp/hcl>`_
+  file format as input file.
+
 - *[FEATURE]* Initial feature set with YAML and JSON file format as input file.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,8 @@
+=========
+Changelog
+=========
+
+Unreleased
+==========
+
+- *[FEATURE]* Initial feature set with YAML and JSON file format as input file.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 j2y - A Jinja2 Template CLI
 ===========================
 
-Render Jinja2 templates on the command line using a YAML file as input for
-the render context.
+Render Jinja2 templates on the command line using a YAML_, JSON_ or HCL_ file
+as input for the render context.
 
 Installation
 ------------
@@ -14,14 +14,15 @@ Installation
 Usage
 -----
 
-By default, ``j2y`` takes a ``YAML`` file as input::
+By default, ``j2y`` takes a YAML_ file as input::
 
   j2y template.j2 < values.yaml
 
-Alternatively you can use JSON as input format::
+Alternatively you can use JSON_ or HCL_ as input format::
 
   j2y template.j2 -f json < values.json
 
+  j2y template.j2 -f hcl < values.hcl
 
 Run ``j2y -h`` to see all available options.
 
@@ -31,7 +32,7 @@ Local Development
 Bootstrapping
 .............
 
-Create a virtualenv and install the package as develop egg::
+Create a virtualenv_ and install the package as develop egg::
 
   $ python -m venv env
   $ env/bin/activate
@@ -44,3 +45,9 @@ At the moment there are very simple test cases only. Test are written as native
 Python doctests. You can invoke them like so::
 
   (env) $ python j2y/tests.py
+
+
+.. _YAML: http://yaml.org/spec/
+.. _JSON: https://www.json.org/
+.. _HCL: https://github.com/hashicorp/hcl
+.. _virtualenv: https://docs.python.org/3/tutorial/venv.html

--- a/j2y/cli.py
+++ b/j2y/cli.py
@@ -6,6 +6,7 @@ j2y - a super simple Jinja2 templating command line interface
 import io
 import os
 import sys
+import hcl
 import json
 import yaml
 import shutil
@@ -35,7 +36,7 @@ def parse_args() -> argparse.Namespace:
                         default=sys.stdout,
                         help='output file, defaults to stdout')
     parser.add_argument('-f', '--format',
-                        choices=['yaml', 'json'],
+                        choices=loaders().keys(),
                         default='yaml',
                         help='input file format')
     parser.add_argument('-x', '--extra', action="append",
@@ -58,6 +59,7 @@ def loaders() -> Dict[str, callable]:
     return {
         'yaml': lambda fp: yaml.load(fp.read()),
         'json': lambda fp: json.load(fp),
+        'hcl': lambda fp: hcl.load(fp),
     }
 
 

--- a/j2y/cli.rst
+++ b/j2y/cli.rst
@@ -38,7 +38,7 @@ Parse program invokation without arguments::
 
   >>> out = parse_args_safe(['j2y'])
   >>> print(out)
-  usage: j2y [-h] [-c CONTEXT] [-o OUTPUT] [-f {yaml,json}] [-x EXTRA] [-v]
+  usage: j2y [-h] [-c CONTEXT] [-o OUTPUT] [-f {yaml,json,hcl}] [-x EXTRA] [-v]
              template
   j2y: error: the following arguments are required: template
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2==2.10
 PyYAML==3.13
+pyhcl==0.3.10


### PR DESCRIPTION
This commit adds support for the HCL (Hashicorp Configuration Language)
file type as input file for the render context.

https://github.com/hashicorp/hcl