### PR TITLE
add support for multiple input files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ==========
 
+- *[FEATURE]* Add support for multiple input files using the ``-c`` or
+  ``--context`` argument.
+
 - *[FEATURE]* Add hashlib digest functions ``md5sum``, ``sha1sum``,
   ``sha256sum`` and ``sha512sum`` as template filters.
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@ Alternatively you can use JSON_ or HCL_ as input format::
   $ j2y template.j2 -f json < values.json
   $ j2y template.j2 -f hcl < values.hcl
 
+It's also possible to provide multiple input files::
+
+  $ j2y template.j2 --context v1.yaml --context v2.yaml
+
 Run ``j2y -h`` to see all available options.
 
 Template Variables

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -48,7 +48,7 @@ Parse default arguments::
   >>> args.template
   PosixPath('template.j2')
   >>> args.context
-  <_pytest.capture.DontReadFromInput object at 0x...>
+  []
   >>> args.extra
   []
   >>> args.format
@@ -70,13 +70,18 @@ Change output file::
   >>> args.output
   <_io.TextIOWrapper name='outfile' mode='w' encoding='UTF-8'>
 
+.. hidden:: Remove output
+
+   >>> args.output.close()
+   >>> os.unlink(args.output.name)
+
 Provide input file, however, it needs to exist::
 
   >>> with tempfile.NamedTemporaryFile() as infile:
   ...     args = parse_args_safe(['j2y', 'template.j2', '-c', infile.name])
   ...     print(args.context)
-  ...     print(args.context.name == infile.name)
-  <_io.TextIOWrapper name='...' mode='r' encoding='UTF-8'>
+  ...     print(args.context[0].name == infile.name)
+  [<_io.TextIOWrapper name='...' mode='r' encoding='UTF-8'>]
   True
 
 Template Rendering

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,15 @@
 [wheel]
-universal=1
+universal = 1
 
 [mypy]
 ignore_missing_imports = True
 
 [flake8]
-ignore = E203, E501, W503
+ignore = E203, W503
 max-line-length = 88
 
 [tool:pytest]
-addopts = --doctest-glob='j2y/*.rst' --flake8 --black --mypy
+flake8-max-line-length = 88
+flake8-ignore = E203, W503
+addopts = --doctest-glob='docs/*.rst' --flake8 --black --mypy --mypy-ignore-missing-imports
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS


### PR DESCRIPTION
using the `-c` or `--context` arguments, e.g.

```console
$ j2y template.j2 -c values1.yaml -c values2.yaml
...
```