### PR TITLE
Fix bug that prevented rendering templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ==========
 
+- Fixed bug that prevented rendering templates that are in different directory
+  than the current working directory.
+
 2020/03/14 0.3.0
 ================
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import io
+import os
+from contextlib import contextmanager
+from j2cli.cli import entrypoint
+
+
+@contextmanager
+def tmp_workdir(path):
+    current = os.getcwd()
+    try:
+        os.chdir(path)
+        yield path
+    finally:
+        os.chdir(current)
+
+
+def test_write_template_in_different_location(tmpdir):
+    template = tmpdir.mkdir("folder_a").join("template.j2")
+    template.write('foo: "{{ value }}"')
+    source = tmpdir.mkdir("folder_b").join("context.yaml")
+    source.write('value: "bar"')
+    output = io.StringIO()
+    with tmp_workdir(tmpdir):
+        entrypoint(str(template), output, contexts=[source])
+    output.seek(0)
+    assert output.read() == 'foo: "bar"\n'


### PR DESCRIPTION
in different directory than the current working directory where the
`j2cli` command is executed.

This now allows to use absolute paths for templates.